### PR TITLE
Add SQLite to store skin and knife config

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -92,6 +92,20 @@ jobs:
           ref: master
           path: metamod-source
 
+      # Download SQLite source code
+      - name: Download SQLite source code(L)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          wget -O sqlite.zip "https://www.sqlite.org/2023/sqlite-amalgamation-3440000.zip"
+          unzip sqlite.zip
+          mv sqlite-amalgamation-3440000 project/sqlite3
+      - name: Download SQLite source code(W)
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          powershell -command "Invoke-WebRequest -Uri 'https://www.sqlite.org/2023/sqlite-amalgamation-3440000.zip' -OutFile 'sqlite.zip';Expand-Archive -Path 'sqlite.zip' -DestinationPath 'project';mv project/sqlite-amalgamation-3440000 project/sqlite3"
+
       # Build
       - name: Build
         shell: bash
@@ -99,6 +113,12 @@ jobs:
           cd project && mkdir build && cd build
           python ../configure.py --enable-optimize --plugin-name=Skin --plugin-alias=Skin --sdks=cs2 --targets=x86_64
           ambuild
+
+      - name: Strip(L)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          strip project/build/package/addons/Skin/Skin.so
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -315,7 +315,7 @@ class MMSPluginConfig(object):
     if builder.options.opt == '1':
       cxx.defines += ['NDEBUG']
       if cxx.behavior == 'gcc':
-        cxx.cflags += ['-O3']
+        cxx.cflags += ['-Oz']
       elif cxx.behavior == 'msvc':
         cxx.cflags += ['/Ox', '/Zo']
         cxx.linkflags += ['/OPT:ICF', '/OPT:REF']

--- a/AMBuilder
+++ b/AMBuilder
@@ -23,6 +23,8 @@ for sdk_name in MMSPlugin.sdks:
       'Skin.cpp',
       'utils/module.cpp',
       'utils/memaddr.cpp',
+      'utils/db.cpp',
+      'sqlite3/sqlite3.c',
       os.path.join('sdk', 'schemasystem.cpp')
     ]
 

--- a/Skin.cpp
+++ b/Skin.cpp
@@ -377,7 +377,9 @@ CON_COMMAND_F(skin, "修改皮肤", FCVAR_CLIENT_CAN_EXECUTE)
 			FnUTIL_ClientPrint(pPlayerController, 3, " \x04 [SKIN] \x01修改刀具控制台输入 'skin 编号 模板 磨损 刀具编号'",nullptr, nullptr, nullptr, nullptr);
 			return;
 		}
-		g_PlayerKnifes[steamid] = atoi(args.Arg(4));
+		int knifeid = atoi(args.Arg(4));
+		g_PlayerKnifes[steamid] = knifeid;
+		db->UpdateKnife(steamid, knifeid);
 	}
 	else
 	{
@@ -432,7 +434,7 @@ CON_COMMAND_F(skin, "修改皮肤", FCVAR_CLIENT_CAN_EXECUTE)
 	g_PlayerSkins[steamid][weaponId].m_nFallbackPaintKit = paintKit;
 	g_PlayerSkins[steamid][weaponId].m_nFallbackSeed = seed;
 	g_PlayerSkins[steamid][weaponId].m_flFallbackWear = wear;
-	db->UpdateData(steamid, weaponId, paintKit, seed, wear);
+	db->UpdateWeapon(steamid, weaponId, paintKit, seed, wear);
 	CBasePlayerWeapon* pPlayerWeapon = pWeaponServices->m_hActiveWeapon();
 
 	pWeaponServices->RemoveWeapon(pPlayerWeapon);

--- a/Skin.h
+++ b/Skin.h
@@ -26,12 +26,21 @@
 #include <deque>
 #include <functional>
 
+typedef struct SkinParm
+{
+	int m_nFallbackPaintKit;
+	int m_nFallbackSeed;
+	float m_flFallbackWear;
+}SkinParm;
+
 class Skin final : public ISmmPlugin, public IMetamodListener
 {
 public:
 	bool Load(PluginId id, ISmmAPI* ismm, char* error, size_t maxlen, bool late);
 	bool Unload(char* error, size_t maxlen);
 	void NextFrame(std::function<void()> fn);
+	void OnClientConnected( CPlayerSlot slot, const char *pszName, uint64 xuid, const char *pszNetworkID, const char *pszAddress, bool bFakePlayer );
+	void ClientDisconnect( CPlayerSlot slot, int reason, const char *pszName, uint64 xuid, const char *pszNetworkID );
 private:
 	const char* GetAuthor();
 	const char* GetName();

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
-mkdir build && cd build
+mkdir -p build && cd build
 python3 ../configure.py --enable-optimize --plugin-name=Skin --plugin-alias=Skin --sdks=cs2 --mms_path=/root/metamod-source --hl2sdk-root=/root/hl2sdk-root/
 ambuild

--- a/utils/db.cpp
+++ b/utils/db.cpp
@@ -1,5 +1,6 @@
 #include "db.h"
 #include <map>
+#include <inttypes.h>
 
 extern ISmmAPI *g_SMAPI;
 extern std::map<uint64_t, std::map<int, SkinParm>> g_PlayerSkins;
@@ -32,7 +33,7 @@ void DB::QueryData(uint64_t steamid)
     sqlite3_stmt *stmt;
 
     // Query weapon table
-    sprintf(buf, "SELECT weaponid,paintkit,seed,wear FROM weapon WHERE steamid=%lu;", steamid);
+    sprintf(buf, "SELECT weaponid,paintkit,seed,wear FROM weapon WHERE steamid=%" PRIu64 ";", steamid);
     std::map<int, SkinParm>& playerSkinMap = g_PlayerSkins[steamid];
     sqlite3_prepare(db, buf, sizeof(buf), &stmt, NULL);
     while (sqlite3_step(stmt) == SQLITE_ROW)
@@ -45,7 +46,7 @@ void DB::QueryData(uint64_t steamid)
     sqlite3_finalize(stmt);
 
     // Query knife table
-    sprintf(buf, "SELECT knifeid FROM knife WHERE steamid=%lu;", steamid);
+    sprintf(buf, "SELECT knifeid FROM knife WHERE steamid=%" PRIu64 ";", steamid);
     sqlite3_prepare(db, buf, sizeof(buf), &stmt, NULL);
     if (sqlite3_step(stmt) == SQLITE_ROW)
     {
@@ -57,14 +58,14 @@ void DB::QueryData(uint64_t steamid)
 
 void DB::UpdateWeapon(uint64_t steamid, int weaponid, int paintKit, int seed, float wear)
 {
-    sprintf(buf, "INSERT OR REPLACE INTO weapon(steamid, weaponid, paintkit, seed, wear) VALUES(%lu, %d, %d, %d, %f);", steamid, weaponid, paintKit, seed, wear);
+    sprintf(buf, "INSERT OR REPLACE INTO weapon(steamid, weaponid, paintkit, seed, wear) VALUES(%" PRIu64 ", %d, %d, %d, %f);", steamid, weaponid, paintKit, seed, wear);
     sqlite3_exec(db, buf, NULL, NULL, &sql3_errmsg);
     CheckErrMSG();
 }
 
 void DB::UpdateKnife(uint64_t steamid, int knifeid)
 {
-    sprintf(buf, "INSERT OR REPLACE INTO knife(steamid, knifeid) VALUES(%lu, %d);", steamid, knifeid);
+    sprintf(buf, "INSERT OR REPLACE INTO knife(steamid, knifeid) VALUES(%" PRIu64 ", %d);", steamid, knifeid);
     sqlite3_exec(db, buf, NULL, NULL, &sql3_errmsg);
     CheckErrMSG();
 }

--- a/utils/db.cpp
+++ b/utils/db.cpp
@@ -1,0 +1,50 @@
+#include "db.h"
+#include <map>
+
+extern ISmmAPI *g_SMAPI;
+extern std::map<uint64_t, std::map<int, SkinParm>> g_PlayerSkins;
+
+DB::DB()
+{
+    g_SMAPI->PathFormat(buf, sizeof(buf), "%s/skin.db3", g_SMAPI->GetBaseDir());
+    sqlite3_open(buf, &db);
+    sqlite3_exec(db, "create table if not exists weapon(steamid integer,weaponid integer,paintkit integer not null,seed integer not null,wear real not null,constraint weapon_pk primary key (steamid,weaponid));", NULL, NULL, &sql3_errmsg);
+    CheckErrMSG();
+}
+
+DB::~DB()
+{
+    sqlite3_close(db);
+}
+
+void DB::CheckErrMSG()
+{
+    if (sql3_errmsg)
+    {
+        META_CONPRINTF("\nSkin %s\n", sql3_errmsg);
+        sqlite3_free(sql3_errmsg);
+    }
+}
+
+void DB::QueryData(uint64_t steamid)
+{
+    sqlite3_stmt *stmt;
+    sprintf(buf, "SELECT weaponid,paintkit,seed,wear FROM weapon WHERE steamid=%lu;", steamid);
+    std::map<int, SkinParm> playerSkinMap = g_PlayerSkins[steamid];
+    sqlite3_prepare(db, buf, sizeof(buf), &stmt, NULL);
+    while (sqlite3_step(stmt) == SQLITE_ROW)
+    {
+        const int weaponid = sqlite3_column_int(stmt, 0);
+        playerSkinMap[weaponid].m_nFallbackPaintKit = sqlite3_column_int(stmt, 1);
+        playerSkinMap[weaponid].m_nFallbackSeed = sqlite3_column_int(stmt, 2);
+        playerSkinMap[weaponid].m_flFallbackWear = static_cast<float>(sqlite3_column_double(stmt, 3));
+    }
+    sqlite3_finalize(stmt);
+}
+
+void DB::UpdateData(uint64_t steamid, int weaponid, int paintKit, int seed, float wear)
+{
+    sprintf(buf, "INSERT OR REPLACE INTO weapon(steamid, weaponid, paintkit, seed, wear) VALUES(%lu, %d, %d, %d, %f);", steamid, weaponid, paintKit, seed, wear);
+    sqlite3_exec(db, buf, NULL, NULL, &sql3_errmsg);
+    CheckErrMSG();
+}

--- a/utils/db.cpp
+++ b/utils/db.cpp
@@ -3,12 +3,13 @@
 
 extern ISmmAPI *g_SMAPI;
 extern std::map<uint64_t, std::map<int, SkinParm>> g_PlayerSkins;
+extern std::map<uint64_t, int> g_PlayerKnifes;
 
 DB::DB()
 {
     g_SMAPI->PathFormat(buf, sizeof(buf), "%s/skin.db3", g_SMAPI->GetBaseDir());
     sqlite3_open(buf, &db);
-    sqlite3_exec(db, "create table if not exists weapon(steamid integer,weaponid integer,paintkit integer not null,seed integer not null,wear real not null,constraint weapon_pk primary key (steamid,weaponid));", NULL, NULL, &sql3_errmsg);
+    sqlite3_exec(db, "create table if not exists weapon(steamid integer,weaponid integer,paintkit integer not null,seed integer not null,wear real not null,constraint weapon_pk primary key (steamid,weaponid));create table if not exists knife(steamid integer,knifeid integer,constraint knife_pk primary key (steamid));", NULL, NULL, &sql3_errmsg);
     CheckErrMSG();
 }
 
@@ -29,8 +30,10 @@ void DB::CheckErrMSG()
 void DB::QueryData(uint64_t steamid)
 {
     sqlite3_stmt *stmt;
+
+    // Query weapon table
     sprintf(buf, "SELECT weaponid,paintkit,seed,wear FROM weapon WHERE steamid=%lu;", steamid);
-    std::map<int, SkinParm> playerSkinMap = g_PlayerSkins[steamid];
+    std::map<int, SkinParm>& playerSkinMap = g_PlayerSkins[steamid];
     sqlite3_prepare(db, buf, sizeof(buf), &stmt, NULL);
     while (sqlite3_step(stmt) == SQLITE_ROW)
     {
@@ -40,11 +43,28 @@ void DB::QueryData(uint64_t steamid)
         playerSkinMap[weaponid].m_flFallbackWear = static_cast<float>(sqlite3_column_double(stmt, 3));
     }
     sqlite3_finalize(stmt);
+
+    // Query knife table
+    sprintf(buf, "SELECT knifeid FROM knife WHERE steamid=%lu;", steamid);
+    sqlite3_prepare(db, buf, sizeof(buf), &stmt, NULL);
+    if (sqlite3_step(stmt) == SQLITE_ROW)
+    {
+        int knifeid = sqlite3_column_int(stmt, 0);
+        g_PlayerKnifes[steamid] = knifeid;
+    }
+    sqlite3_finalize(stmt);
 }
 
-void DB::UpdateData(uint64_t steamid, int weaponid, int paintKit, int seed, float wear)
+void DB::UpdateWeapon(uint64_t steamid, int weaponid, int paintKit, int seed, float wear)
 {
     sprintf(buf, "INSERT OR REPLACE INTO weapon(steamid, weaponid, paintkit, seed, wear) VALUES(%lu, %d, %d, %d, %f);", steamid, weaponid, paintKit, seed, wear);
+    sqlite3_exec(db, buf, NULL, NULL, &sql3_errmsg);
+    CheckErrMSG();
+}
+
+void DB::UpdateKnife(uint64_t steamid, int knifeid)
+{
+    sprintf(buf, "INSERT OR REPLACE INTO knife(steamid, knifeid) VALUES(%lu, %d);", steamid, knifeid);
     sqlite3_exec(db, buf, NULL, NULL, &sql3_errmsg);
     CheckErrMSG();
 }

--- a/utils/db.h
+++ b/utils/db.h
@@ -14,5 +14,6 @@ public:
     DB();
     ~DB();
     void QueryData(uint64_t steamid);
-    void UpdateData(uint64_t steamid, int weaponid, int paintKit, int seed, float wear);
+    void UpdateWeapon(uint64_t steamid, int weaponid, int paintKit, int seed, float wear);
+    void UpdateKnife(uint64_t steamid, int knifeid);
 };

--- a/utils/db.h
+++ b/utils/db.h
@@ -1,0 +1,18 @@
+#include "sqlite3/sqlite3.h"
+#include "Skin.h"
+#include <map>
+
+class DB
+{
+private:
+    sqlite3 *db;
+    char buf[2048];
+    char *sql3_errmsg = nullptr;
+    void CheckErrMSG();
+
+public:
+    DB();
+    ~DB();
+    void QueryData(uint64_t steamid);
+    void UpdateData(uint64_t steamid, int weaponid, int paintKit, int seed, float wear);
+};


### PR DESCRIPTION
引入SQLite库来存储皮肤和刀的信息，并在玩家连接上服务器后自动加载对应的数据。
### 编译
需要从SQLite官网下载源码并解压到项目路径下的sqlite3文件夹下
https://www.sqlite.org/download.html

---
Introduced SQLite library to store information about skins and knives and automatically load the corresponding data when the player connects to the server.
### Compile
You need to download the source code from the SQLite website and extract it to the sqlite3 folder under the project path
https://www.sqlite.org/download.html